### PR TITLE
Add PCA rules to the pipeline

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -87,3 +87,24 @@ rule get_merizo_predictions:
             -i {input.structure_file} \
             > {output.output_file}
         """
+
+rule build_dcd_file:
+    input:
+        traj="data/traj/{protein_name}.xtc"
+    output:
+        dcd_file="output/pca/{protein_name}.dcd"
+    shell:
+        """
+        mdconvert {input.traj} -o {output.dcd_file}
+        """
+
+rule build_nmd_file:
+    input:
+        pdb_file="data/pdb/{protein_name}.pdb",
+        dcd_file="output/pca/{protein_name}.dcd"
+    output:
+        nmd_file="output/pca/{protein_name}.nmd"
+    shell:
+        """
+        python scripts/build_nmd_file.py {input.pdb_file} {input.dcd_file} {output.nmd_file}
+        """

--- a/Snakefile
+++ b/Snakefile
@@ -88,15 +88,15 @@ rule get_merizo_predictions:
             > {output.output_file}
         """
 
-rule build_dcd_file:
-    input:
-        traj="data/traj/{protein_name}.xtc"
-    output:
-        dcd_file="output/pca/{protein_name}.dcd"
-    shell:
-        """
-        mdconvert {input.traj} -o {output.dcd_file}
-        """
+rule build_dcd_file_from_xtc:
+    input: traj="data/traj/{protein_name}.xtc"
+    output: dcd_file="output/pca/{protein_name}.dcd"
+    shell: "mdconvert {input.traj} -o {output.dcd_file}"
+
+rule build_dcd_file_from_trr:
+    input: traj="data/traj/{protein_name}.trr"
+    output: dcd_file="output/pca/{protein_name}.dcd"
+    shell: "mdconvert {input.traj} -o {output.dcd_file}"
 
 rule build_nmd_file:
     input:

--- a/scripts/build_nmd_file.py
+++ b/scripts/build_nmd_file.py
@@ -15,7 +15,7 @@ protein_name = Path(pdb_file).stem
 
 ensemble = parseDCD(dcd_file)
 num_atoms = ensemble.numAtoms()
-structure = parsePDB(pdb_file).select('index 1 to %d' % num_atoms)
+structure = parsePDB(pdb_file)
 
 ensemble.setCoords(structure)
 ensemble.setAtoms(structure)
@@ -23,4 +23,6 @@ ensemble.superpose()
 
 eda_ensemble = EDA('%s Ensemble' % protein_name)
 eda_ensemble.buildCovariance(ensemble)
-eda_ensemble.calcModes(n_modes=10) # can do more but will take longer
+eda_ensemble.calcModes(n_modes=3) # can do more but will take longer
+
+writeNMD(output_file, eda_ensemble[:3], structure)

--- a/scripts/build_nmd_file.py
+++ b/scripts/build_nmd_file.py
@@ -1,6 +1,7 @@
 import sys
 import os
-from prody import parseDCD, parsePDB, writeNMD
+from pathlib import Path
+from prody import parseDCD, parsePDB, writeNMD, EDA
 
 if len(sys.argv) < 4:
     print(f"USAGE: python {os.path.basename(__file__)} <protein.pdb> <protein.dcd> <output.nmd>")
@@ -10,6 +11,8 @@ pdb_file    = sys.argv[1]
 dcd_file    = sys.argv[2]
 output_file = sys.argv[3]
 
+protein_name = Path(pdb_file).stem
+
 ensemble = parseDCD(dcd_file)
 num_atoms = ensemble.numAtoms()
 structure = parsePDB(pdb_file).select('index 1 to %d' % num_atoms)
@@ -18,6 +21,6 @@ ensemble.setCoords(structure)
 ensemble.setAtoms(structure)
 ensemble.superpose()
 
-eda_ensemble = EDA('%s Ensemble' % wildcards.protein_name)
+eda_ensemble = EDA('%s Ensemble' % protein_name)
 eda_ensemble.buildCovariance(ensemble)
 eda_ensemble.calcModes(n_modes=10) # can do more but will take longer

--- a/scripts/build_nmd_file.py
+++ b/scripts/build_nmd_file.py
@@ -1,0 +1,23 @@
+import sys
+import os
+from prody import parseDCD, parsePDB, writeNMD
+
+if len(sys.argv) < 4:
+    print(f"USAGE: python {os.path.basename(__file__)} <protein.pdb> <protein.dcd> <output.nmd>")
+    sys.exit(1)
+
+pdb_file    = sys.argv[1]
+dcd_file    = sys.argv[2]
+output_file = sys.argv[3]
+
+ensemble = parseDCD(dcd_file)
+num_atoms = ensemble.numAtoms()
+structure = parsePDB(pdb_file).select('index 1 to %d' % num_atoms)
+
+ensemble.setCoords(structure)
+ensemble.setAtoms(structure)
+ensemble.superpose()
+
+eda_ensemble = EDA('%s Ensemble' % wildcards.protein_name)
+eda_ensemble.buildCovariance(ensemble)
+eda_ensemble.calcModes(n_modes=10) # can do more but will take longer


### PR DESCRIPTION
This is set up to work with either an xtc or a trr file. We should figure out the right combinations of trajectory and pdb files from zenodo to put into the "data" directory and what conversions to run on them to get the right output.

It also seems mega slow, both on the VSC and on my laptop. It's probably not something we'll be running inside of blender.