### PR TITLE
Try MD-TASK for segmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ bash install_micromamba.sh
 
 **Important**: When asked for a "root prefix", choose `.micromamba`, without the `~` at the beginning. By default, micromamba creates environments in the home directory. You don't want that on the VSC or you'll run out of quota. Choosing `.micromamba` is going to install packages inside of the repo itself in a folder `.micromamba`, which is gitignored.
 
-Set up and activate an environment:
+Set up and activate a `protein-runway` environment from the env file in the repo:
 
 ```bash
-micromamba create -n protein-runway -c conda-forge python=3.11
+micromamba create -f micromamba_env.yml
 micromamba activate protein-runway
 ```
 

--- a/Snakefile
+++ b/Snakefile
@@ -90,7 +90,7 @@ rule mdtask_qa:
             --lazy-load
         """
 
-rule get_chainsaw_predictions:
+rule get_chainsaw_clustering:
     input:
         structure_file="data/pdb/{pdb_file}.pdb",
         chainsaw_ok=CHAINSAW_OK
@@ -103,7 +103,7 @@ rule get_chainsaw_predictions:
             --output {output.output_file}
         """
 
-rule get_merizo_predictions:
+rule get_merizo_clustering:
     input:
         structure_file="data/pdb/{pdb_file}.pdb",
         merizo_ok=MERIZO_OK
@@ -115,6 +115,16 @@ rule get_merizo_predictions:
             -d cpu \
             -i {input.structure_file} \
             > {output.output_file}
+        """
+
+rule get_mdtask_clustering:
+    input:
+        correlation_file="output/correlation/{pdb_file}.txt"
+    output:
+        output_file="output/correlation/{pdb_file}.tsv"
+    shell:
+        """
+        python scripts/segment_by_correlation.py {input.correlation_file} {output.output_file}
         """
 
 rule build_dcd_file_from_xtc:

--- a/micromamba_env.yml
+++ b/micromamba_env.yml
@@ -1,0 +1,12 @@
+name: protein-runway
+channels:
+  - conda-forge
+  - anaconda
+  - bioconda
+dependencies:
+  - python =3.11
+  - prody
+  - snakemake
+
+  # For MD-TASK:
+  - r-igraph

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,12 +7,10 @@ mdtraj
 
 # For merizo:
 einops
-matplotlib
 natsort
 networkx
 numpy<2
 rotary_embedding_torch
-scipy
 setuptools
 
 # For chainsaw:
@@ -29,7 +27,6 @@ iniconfig==2.0.0
 Jinja2==3.1.2
 kiwisolver==1.4.4
 MarkupSafe==2.1.2
-matplotlib==3.7.1
 mpmath==1.3.0
 networkx==3.1
 notebook==6.5.4
@@ -45,7 +42,6 @@ python-dateutil==2.8.2
 pytz==2023.3
 requests==2.31.0
 ruff==0.0.269
-scipy==1.10.1
 six==1.16.0
 sympy==1.12
 typing_extensions==4.6.0
@@ -54,3 +50,10 @@ urllib3==2.0.2
 
 # For chainsaw & merizo
 torch==2.0.1
+scipy==1.10.1
+matplotlib==3.7.1
+
+# For md-task
+matplotlib
+cython
+networkx

--- a/scripts/build_nmd_file.py
+++ b/scripts/build_nmd_file.py
@@ -18,6 +18,10 @@ num_atoms = ensemble.numAtoms()
 structure = parsePDB(pdb_file)
 
 ensemble.setCoords(structure)
+
+# Limit to alpha carbons to keep a low memory profile
+structure = structure.select('calpha')
+
 ensemble.setAtoms(structure)
 ensemble.superpose()
 

--- a/scripts/segment_by_correlation.py
+++ b/scripts/segment_by_correlation.py
@@ -1,0 +1,60 @@
+import sys
+import os
+import csv
+from pathlib import Path
+
+import numpy as np
+import scipy.cluster.hierarchy as spc
+
+if len(sys.argv) < 3:
+    print(f"USAGE: python {os.path.basename(__file__)} <correlation.txt> <output.tsv>")
+    sys.exit(1)
+
+correlation_file = sys.argv[1]
+output_file      = sys.argv[2]
+
+protein_name = Path(correlation_file).stem
+
+correlation_matrix = np.loadtxt(correlation_file)
+
+# Code adapted from: https://stackoverflow.com/a/76042335
+pdist_uncondensed = 1.0 - correlation_matrix
+pdist_condensed = np.concatenate([row[i+1:] for i, row in enumerate(pdist_uncondensed)])
+linkage = spc.linkage(pdist_condensed, method='complete')
+clusters = spc.fcluster(linkage, 0.5 * pdist_condensed.max(), 'distance')
+
+# Structure: { group: [(start, end), (start, end), ...] }
+groupings = {}
+
+for i, group in enumerate(clusters):
+    new_residue = i + 1
+
+    if group not in groupings:
+        groupings[group] = [(new_residue,)]
+        continue
+
+    last_pair = groupings[group][-1]
+
+    if len(last_pair) == 1:
+        # We only have the first item in the (start, end) pair, add the second one
+        start_residue,  = last_pair
+        groupings[group][-1] = (start_residue, new_residue)
+    elif len(last_pair) == 2:
+        start_residue, end_residue = last_pair
+
+        if new_residue - end_residue == 1:
+            # this is the next one, just extend the range:
+            groupings[group][-1] = (start_residue, new_residue)
+        else:
+            groupings[group].append((new_residue,))
+
+group_descriptions = []
+for i in range(1, max(groupings.keys())):
+    group_descriptions.append('_'.join([f"{start}-{end}" for start, end in groupings[i]]))
+
+description = ','.join(group_descriptions)
+
+with open(output_file, 'w') as out:
+    writer = csv.writer(out, delimiter='\t', quoting=csv.QUOTE_MINIMAL, dialect='unix')
+    writer.writerow(("chain_id", "nres", "ndom", "chopping"))
+    writer.writerow((protein_name, len(clusters), max(clusters), description))

--- a/scripts/segment_by_correlation.py
+++ b/scripts/segment_by_correlation.py
@@ -49,7 +49,7 @@ for i, group in enumerate(clusters):
             groupings[group].append((new_residue,))
 
 group_descriptions = []
-for i in range(1, max(groupings.keys())):
+for i in range(1, max(groupings.keys()) + 1):
     group_descriptions.append('_'.join([f"{start}-{end}" for start, end in groupings[i]]))
 
 description = ','.join(group_descriptions)


### PR DESCRIPTION
MD-TASK can measure the correlation of movement of atoms, and we could use that for clustering. That said, the current results are a bit choppy. There might be other kinds of segmentation algorithms that are more prone to generating contiguous segments, but we need to experiment.

Using normal modes instead of basic trajectories might also smooth things out, but I still haven't gotten around to figuring out how to logically translate normal mode information into trajectory correlation.

This PR also introduces an environment file for micromamba so we can add packages there that don't install smoothly using pip. From what I understand, the conda-compatible repositories contain packages that are already compiled, while pip is going to try to build them on the fly and might choke.

The correlation png: 
![spike_protein_md](https://github.com/user-attachments/assets/7c430cb0-df79-4106-bd45-38e3eee0cbe3)

The chopping, 4 domains:
```
207-208_224-242_277-286_296-304_411-427_431-438_471-483_491-568_864-867_895-904_918-942_944-945_961-973
243-276_287-295_305-410_428-430_439-470_905-917_943-960
1-206_209-223_484-490_569-580_650-657_669-679_725-801_829-833_836-840_843-847_850-854_858-863_868-878_887-894
581-649_658-668_680-724_726-727_802-828_830-831_834-835_837-838_841-842_844-846_848-849_851-853_855-857_859-861_879-886
```

Yeah, it's not great. It's something, I guess.