### PR TITLE
Render atoms of uploaded file, animate trajectory

### DIFF
--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -1,4 +1,9 @@
+from pathlib import Path
+
 import bpy
+import bmesh
+import mathutils
+
 import MDAnalysis as mda
 
 bpy.types.Scene.ProteinRunway_local_path = bpy.props.StringProperty(
@@ -22,19 +27,115 @@ class ImportTrajectoryOperator(bpy.types.Operator):
     def execute(self, context):
         scene = context.scene
         file_path = scene.ProteinRunway_local_path
+        protein_name = Path(file_path).stem
 
         u = mda.Universe(file_path)
 
-        # For now, just print a message:
-        message = f"Atoms: {len(u.atoms)}, Frames: {len(u.trajectory)}"
-        self.report({'INFO'}, message)
+        scene = bpy.context.scene
+        collection_protein = bpy.data.collections.new(protein_name)
+        scene.collection.children.link(collection_protein)
 
-        # Also render a panel with information:
-        def draw(self, context):
-            self.layout.label(text=message)
-        bpy.context.window_manager.popup_menu(draw, title="Example", icon="INFO")
+        atom_mesh_object = self.draw_alpha_carbons(u, collection_protein)
+        self.animate_trajectory(u, atom_mesh_object)
+
+        # TODO (2024-11-14) This is messy and invasive, it might interfere with
+        # multiple trajectories
+        #
+        # Fit the number of global frames to this trajectory's length.
+        bpy.data.scenes[0].frame_end = len(u.trajectory)
 
         return {'FINISHED'}
+
+    def draw_alpha_carbons(self, universe, collection_protein):
+        atoms = universe.select_atoms('name = CA')
+
+        center = atoms.center_of_mass()
+        vertices = [p - center for p in atoms.positions]
+
+        color = (0.3, 0.3, 0.3, 1)
+        radius = 0.7
+
+        material = bpy.data.materials.new("Carbon_material")
+        material.diffuse_color = color
+        material.use_nodes = True
+
+        # TODO: Investigate this material modification by Atomic Blender:
+        #
+        # mat_P_BSDF = next(n for n in material.node_tree.nodes
+        #                   if n.type == "BSDF_PRINCIPLED")
+        # mat_P_BSDF.inputs['Base Color'].default_value = color
+
+        material.name = "Carbon_material"
+
+        atom_mesh = bpy.data.meshes.new("Mesh_carbon")
+        atom_mesh.from_pydata(vertices, [], [])
+        atom_mesh.update()
+        atom_mesh_object = bpy.data.objects.new("Carbon_mesh_object", atom_mesh)
+        collection_protein.objects.link(atom_mesh_object)
+
+        # UV balls
+        bpy.ops.mesh.primitive_uv_sphere_add(
+            segments=32,
+            ring_count=32,
+            align='WORLD',
+            enter_editmode=False,
+            location=(0, 0, 0),
+            rotation=(0, 0, 0)
+        )
+
+        representative_ball = bpy.context.view_layer.objects.active
+        representative_ball.hide_set(True)
+        representative_ball.scale = (radius, radius, radius)
+        representative_ball.active_material = material
+        representative_ball.parent = atom_mesh_object
+
+        atom_mesh_object.instance_type = 'VERTS'
+
+        # TODO (2024-11-14) Taken from Atomic Blender, check if it's necessary:
+        #
+        # Note the collection where the ball was placed into.
+        coll_all = representative_ball.users_collection
+        if len(coll_all) > 0:
+            coll_past = coll_all[0]
+        else:
+            coll_past = bpy.context.scene.collection
+
+        # Put the atom into the new collection 'atom' and ...
+        collection_protein.objects.link(representative_ball)
+        # ... unlink the atom from the other collection.
+        coll_past.objects.unlink(representative_ball)
+
+        atom_mesh_object.select_set(True)
+
+        return atom_mesh_object
+
+    def animate_trajectory(self, universe, atom_mesh_object):
+        mesh = atom_mesh_object.data
+
+        # Snapshot first frame:
+        for v in mesh.vertices:
+            v.keyframe_insert('co', frame=1)
+        frame = 2
+
+        for _ in universe.trajectory[1:]:
+            atoms = universe.select_atoms('name = CA')
+            center = atoms.center_of_mass()
+            vertices = [p - center for p in atoms.positions]
+
+            # Perform the calculations using a BMesh:
+            bm = bmesh.new()
+            bm.from_mesh(mesh)
+            for i, v in enumerate(bm.verts):
+                v.co = mathutils.Vector(vertices[i])
+            bm.to_mesh(mesh)
+            bm.free()
+
+            mesh.update()
+
+            for v in mesh.vertices:
+                v.keyframe_insert('co', frame=frame)
+
+            frame += 1
 
 
 class ImportTrajectoryPanel(bpy.types.Panel):


### PR DESCRIPTION
This PR borrows from Atomic Blender, particularly the function `draw_atoms_one_type` in the `pdb_import` file: <https://projects.blender.org/extensions/io_mesh_atomic/src/branch/main/source/pdb_import.py#L657>

It's not exactly the same code, but their "instancing" method is pretty sensible. The individual atom points are considered part of the same "mesh" rather than separate objects. Their color and material is rendered based on a representative point.

Animating this means changing the "co" property of the individual vertices. This is the slowest part. We should look for ways to make this more efficient, but we probably should offload this in some way to something that processes each frame and then gives back a progress indicator. Here's a discussion with an example implementation: <https://blenderartists.org/t/using-new-layout-progress-function-in-4-0/1493965/7>