### PR TITLE
Fix bug with unclassified points

### DIFF
--- a/blender/extension/ui/animate_trajectory_operator.py
+++ b/blender/extension/ui/animate_trajectory_operator.py
@@ -88,17 +88,41 @@ class AnimateTrajectoryOperator(bpy.types.Operator):
             self.current_frame += 1
         else:
             next(self.universe.trajectory)
+
             all_atoms     = self.universe.select_atoms('name = CA')
+            all_resnums   = {a.resnum for a in all_atoms.atoms}
             global_center = all_atoms.center_of_mass()
+            seen_resnums  = set()
 
             for i, domain in enumerate(self.domain_regions):
-                atoms = sum(
+                atom_group = sum(
                     all_atoms.select_atoms("resnum {}:{}".format(region.start, region.stop))
                     for region in domain
                 )
+                seen_resnums |= {a.resnum for a in atom_group.atoms}
 
                 mesh     = self.meshes[i]
-                vertices = [p - global_center for p in atoms.positions]
+                vertices = [p - global_center for p in atom_group.positions]
+
+                # Perform the calculations using a BMesh:
+                bm = bmesh.new()
+                bm.from_mesh(mesh)
+                for i, v in enumerate(bm.verts):
+                    v.co = mathutils.Vector(vertices[i])
+                bm.to_mesh(mesh)
+                bm.free()
+                mesh.update()
+
+            # Add leftover atoms, if any:
+            unseen_resnums = all_resnums - seen_resnums
+            if len(unseen_resnums) > 0:
+                atom_group = sum(
+                    all_atoms.select_atoms("resnum {}".format(str(resnum)))
+                    for resnum in unseen_resnums
+                )
+
+                mesh     = self.meshes[len(self.domain_regions)]
+                vertices = [p - global_center for p in atom_group.positions]
 
                 # Perform the calculations using a BMesh:
                 bm = bmesh.new()

--- a/blender/extension/ui/animate_trajectory_operator.py
+++ b/blender/extension/ui/animate_trajectory_operator.py
@@ -105,13 +105,7 @@ class AnimateTrajectoryOperator(bpy.types.Operator):
                 vertices = [p - global_center for p in atom_group.positions]
 
                 # Perform the calculations using a BMesh:
-                bm = bmesh.new()
-                bm.from_mesh(mesh)
-                for i, v in enumerate(bm.verts):
-                    v.co = mathutils.Vector(vertices[i])
-                bm.to_mesh(mesh)
-                bm.free()
-                mesh.update()
+                self.update_mesh_coordinates(mesh, vertices)
 
             # Add leftover atoms, if any:
             unseen_resnums = all_resnums - seen_resnums
@@ -124,17 +118,22 @@ class AnimateTrajectoryOperator(bpy.types.Operator):
                 mesh     = self.meshes[len(self.domain_regions)]
                 vertices = [p - global_center for p in atom_group.positions]
 
-                # Perform the calculations using a BMesh:
-                bm = bmesh.new()
-                bm.from_mesh(mesh)
-                for i, v in enumerate(bm.verts):
-                    v.co = mathutils.Vector(vertices[i])
-                bm.to_mesh(mesh)
-                bm.free()
-                mesh.update()
+                self.update_mesh_coordinates(mesh, vertices)
 
             self.save_keyframes()
             self.current_frame += 1
+
+    def update_mesh_coordinates(self, mesh, vertices):
+        # Perform the calculations using a BMesh:
+        bm = bmesh.new()
+        bm.from_mesh(mesh)
+        for i, v in enumerate(bm.verts):
+            v.co = mathutils.Vector(vertices[i])
+
+        # Write the bmesh to the real mesh
+        bm.to_mesh(mesh)
+        bm.free()
+        mesh.update()
 
     def save_keyframes(self):
         for mesh in self.meshes:

--- a/blender/extension/ui/import_pdb_operator.py
+++ b/blender/extension/ui/import_pdb_operator.py
@@ -8,15 +8,15 @@ import MDAnalysis as mda
 from ..lib.segmentation import generate_domain_ranges
 
 COLORS = [
-    (1.0, 1.0, 1.0, 1), # white
-    (0.8, 0.1, 0.1, 1), # red
-    (0.1, 0.8, 0.1, 1), # green
-    (0.1, 0.1, 0.8, 1), # blue
-    (0.8, 0.8, 0.1, 1), # yellow
-    (0.8, 0.3, 0.8, 1), # violet
-    (0.3, 0.8, 0.8, 1), # cyan
-    (0.3, 0.3, 0.3, 1), # gray
+    (1.0, 1.0, 1.0, 1),  # white
+    (0.8, 0.1, 0.1, 1),  # red
+    (0.1, 0.8, 0.1, 1),  # green
+    (0.1, 0.1, 0.8, 1),  # blue
+    (0.8, 0.8, 0.1, 1),  # yellow
+    (0.8, 0.1, 0.8, 1),  # violet
+    (0.1, 0.8, 0.8, 1),  # cyan
 ]
+GRAY = (0.3, 0.3, 0.3, 1)
 
 
 class ImportPDBOperator(bpy.types.Operator):
@@ -44,8 +44,8 @@ class ImportPDBOperator(bpy.types.Operator):
             self.report({'ERROR'}, f"MDAnalysis error: {e}")
             return {'CANCELLED'}
 
-        collection_protein = bpy.data.collections.new(protein_name)
-        scene.collection.children.link(collection_protein)
+        self.collection_protein = bpy.data.collections.new(protein_name)
+        scene.collection.children.link(self.collection_protein)
 
         segmentations = scene.ProteinRunway_segmentations
         if len(segmentations) > 0:
@@ -55,9 +55,9 @@ class ImportPDBOperator(bpy.types.Operator):
             domain_regions = generate_domain_ranges(selected_segmentation.chopping)
         else:
             # One domain for the entire protein:
-            domain_regions = [[range(1, len(u.atoms))]]
+            domain_regions = [[range(1, len(u.atom_group))]]
 
-        atom_mesh_objects = self.draw_alpha_carbons(u, collection_protein, domain_regions, add_convex_hull)
+        atom_mesh_objects = self.draw_alpha_carbons(u, domain_regions, add_convex_hull)
 
         for o in atom_mesh_objects:
             o.select_set(True)
@@ -71,93 +71,115 @@ class ImportPDBOperator(bpy.types.Operator):
 
         return {'FINISHED'}
 
-    def draw_alpha_carbons(self, universe, collection_protein, domain_regions, add_convex_hull):
+    def draw_alpha_carbons(self, universe, domain_regions, add_convex_hull):
         all_atoms     = universe.select_atoms('name = CA')
         global_center = all_atoms.center_of_mass()
-
-        radius = 0.7
+        all_resnums   = {a.resnum for a in all_atoms.atoms}
 
         atom_mesh_objects = []
+        seen_resnums = set()
 
         for i, domain in enumerate(domain_regions):
             color       = COLORS[i % len(COLORS)]
             domain_name = f"Domain{i + 1:02}"
 
-            atoms = sum(
+            atom_group = sum(
                 all_atoms.select_atoms("resnum {}:{}".format(region.start, region.stop))
                 for region in domain
             )
+            seen_resnums |= {a.resnum for a in atom_group.atoms}
+            vertices = [p - global_center for p in atom_group.positions]
 
-            local_center = atoms.center_of_mass() - global_center
-            vertices     = [p - global_center for p in atoms.positions]
+            atom_mesh_object = self.draw_domain(vertices, domain_name, color, add_convex_hull)
+            atom_mesh_objects.append(atom_mesh_object)
 
-            material = bpy.data.materials.new(f"{domain_name}_material")
-            material.diffuse_color = color
-            material.use_nodes = True
+        # Add leftover atoms, if any:
+        unseen_resnums = all_resnums - seen_resnums
+        if len(unseen_resnums) > 0:
+            color       = GRAY
+            domain_name = "Domain_NA"
 
-            # TODO: Investigate this material modification by Atomic Blender:
-            #
-            # mat_P_BSDF = next(n for n in material.node_tree.nodes
-            #                   if n.type == "BSDF_PRINCIPLED")
-            # mat_P_BSDF.inputs['Base Color'].default_value = color
-
-            material.name = f"{domain_name}_material"
-
-            atom_mesh = bpy.data.meshes.new(f"{domain_name}_mesh")
-            atom_mesh.from_pydata(vertices, [], [])
-            atom_mesh.update()
-            atom_mesh_object = bpy.data.objects.new(f"{domain_name}_mesh_object", atom_mesh)
-
-            collection_domain = bpy.data.collections.new(domain_name)
-            collection_protein.children.link(collection_domain)
-            collection_domain.objects.link(atom_mesh_object)
-
-            if add_convex_hull:
-                # Create the convex hull
-                bm = bmesh.new()
-                bm.from_mesh(atom_mesh_object.data)
-                hull = bmesh.ops.convex_hull(bm, input=bm.verts)
-                bm.to_mesh(atom_mesh_object.data)
-                bm.free()
-
-                # We can choose to color the hull:
-                atom_mesh_object.active_material = material
-
-                # We can make the outer points invisible:
-                radius = 0
-
-            # Create a representative UV ball for the carbons
-            bpy.ops.mesh.primitive_uv_sphere_add(
-                segments=32,
-                ring_count=32,
-                align='WORLD',
-                enter_editmode=False,
-                location=(0, 0, 0),
-                rotation=(0, 0, 0)
+            atom_group = sum(
+                all_atoms.select_atoms("resnum {}".format(str(resnum)))
+                for resnum in unseen_resnums
             )
+            vertices = [p - global_center for p in atom_group.positions]
 
-            representative_ball = bpy.context.view_layer.objects.active
-            representative_ball.hide_set(True)
-            representative_ball.scale = (radius, radius, radius)
-            representative_ball.active_material = material
-            representative_ball.parent = atom_mesh_object
-
-            atom_mesh_object.instance_type = 'VERTS'
-
-            # TODO (2024-11-14) Taken from Atomic Blender, check if it's necessary:
-
-            # Note the collection where the ball was placed into.
-            coll_all = representative_ball.users_collection
-            if len(coll_all) > 0:
-                coll_past = coll_all[0]
-            else:
-                coll_past = bpy.context.scene.collection
-
-            # Put the atom into the new collection 'atom' and ...
-            collection_protein.objects.link(representative_ball)
-            # ... unlink the atom from the other collection.
-            coll_past.objects.unlink(representative_ball)
-
+            # Note: We do not add a convex hull for the unclassified atoms,
+            # since they will be spread out
+            atom_mesh_object = self.draw_domain(vertices, domain_name, color, False)
             atom_mesh_objects.append(atom_mesh_object)
 
         return atom_mesh_objects
+
+    def draw_domain(self, vertices, domain_name, color, add_convex_hull):
+        material = bpy.data.materials.new(f"{domain_name}_material")
+        material.diffuse_color = color
+        material.use_nodes = True
+
+        # TODO: Investigate this material modification by Atomic Blender:
+        #
+        # mat_P_BSDF = next(n for n in material.node_tree.nodes
+        #                   if n.type == "BSDF_PRINCIPLED")
+        # mat_P_BSDF.inputs['Base Color'].default_value = color
+
+        material.name = f"{domain_name}_material"
+
+        atom_mesh = bpy.data.meshes.new(f"{domain_name}_mesh")
+        atom_mesh.from_pydata(vertices, [], [])
+        atom_mesh.update()
+        atom_mesh_object = bpy.data.objects.new(f"{domain_name}_mesh_object", atom_mesh)
+
+        collection_domain = bpy.data.collections.new(domain_name)
+        self.collection_protein.children.link(collection_domain)
+        collection_domain.objects.link(atom_mesh_object)
+
+        if add_convex_hull:
+            # Create the convex hull
+            bm = bmesh.new()
+            bm.from_mesh(atom_mesh_object.data)
+            bmesh.ops.convex_hull(bm, input=bm.verts)
+            bm.to_mesh(atom_mesh_object.data)
+            bm.free()
+
+            # We can choose to color the hull:
+            atom_mesh_object.active_material = material
+
+            # We can make the outer points invisible:
+            radius = 0.0
+        else:
+            radius = 1.0
+
+        # Create a representative UV ball for the carbons
+        bpy.ops.mesh.primitive_uv_sphere_add(
+            segments=32,
+            ring_count=32,
+            align='WORLD',
+            enter_editmode=False,
+            location=(0, 0, 0),
+            rotation=(0, 0, 0)
+        )
+
+        representative_ball = bpy.context.view_layer.objects.active
+        representative_ball.hide_set(True)
+        representative_ball.scale = (radius, radius, radius)
+        representative_ball.active_material = material
+        representative_ball.parent = atom_mesh_object
+
+        atom_mesh_object.instance_type = 'VERTS'
+
+        # TODO (2024-11-14) Taken from Atomic Blender, check if it's necessary:
+
+        # Note the collection where the ball was placed into.
+        coll_all = representative_ball.users_collection
+        if len(coll_all) > 0:
+            coll_past = coll_all[0]
+        else:
+            coll_past = bpy.context.scene.collection
+
+        # Put the atom into the new collection 'atom' and ...
+        self.collection_protein.objects.link(representative_ball)
+        # ... unlink the atom from the other collection.
+        coll_past.objects.unlink(representative_ball)
+
+        return atom_mesh_object


### PR DESCRIPTION
Residues that were not included in the chopping were also not included in the visualization. This was an oversight. I've added one extra domain for "leftover" atoms and made sure that that one is gray, and no others are. The atoms stick out a bit (they're not wrapped in a hull, because they're spread out), but it's better than missing them.