### PR TITLE
Snakemake GitHub action

### DIFF
--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -16,17 +16,13 @@ jobs:
       - uses: mamba-org/setup-micromamba@v2
         with:
           environment-file: micromamba_env.yml
-          init-shell: >-
-            bash
           cache-environment: true
           post-cleanup: 'all'
 
       - name: Install pip dependencies
         run: |
-          micromamba activate protein-runway
-          pip install -r requirements.txt
+          micromamba run pip install -r requirements.txt
 
       - name: Run snakemake
         run: |
-          micromamba activate protein-runway
-          snakemake
+          micromamba run snakemake

--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           environment-file: micromamba_env.yml
           cache-environment: true
+          post-cleanup: 'none'
 
       - name: Install pip dependencies
         run: |

--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Install pip dependencies
         run: |
-          micromamba run pip install -r requirements.txt
+          micromamba run -n protein-runway pip install -r requirements.txt
 
       - name: Run snakemake
         run: |
-          micromamba run snakemake
+          micromamba run -n protein-runway snakemake

--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -17,7 +17,6 @@ jobs:
         with:
           environment-file: micromamba_env.yml
           cache-environment: true
-          post-cleanup: 'all'
 
       - name: Install pip dependencies
         run: |

--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -21,10 +21,12 @@ jobs:
           cache-environment: true
           post-cleanup: 'all'
 
-      - name: Install pip requirements
+      - name: Install pip dependencies
         run: |
+          micromamba activate protein-runway
           pip install -r requirements.txt
 
       - name: Run snakemake
         run: |
+          micromamba activate protein-runway
           snakemake

--- a/.github/workflows/snakemake.yml
+++ b/.github/workflows/snakemake.yml
@@ -1,0 +1,30 @@
+name: Run snakemake workflow
+
+on: [push]
+
+jobs:
+  run_snakemake_workflow:
+    name: Build the entire workflow with the example inputs in git
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+            python-version: '3.11'
+
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          environment-file: micromamba_env.yml
+          init-shell: >-
+            bash
+          cache-environment: true
+          post-cleanup: 'all'
+
+      - name: Install pip requirements
+        run: |
+          pip install -r requirements.txt
+
+      - name: Run snakemake
+        run: |
+          snakemake


### PR DESCRIPTION
This github action will run the full snakemake workflow on every push with the example file added in git. With caching of the micromamba files, this seems to take ~2 minutes. This can tell us if a change we made accidentally broke the environment.