### PR TITLE
Separate segmentation lists

### DIFF
--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -4,15 +4,22 @@ import json
 from .ui.import_pdb_operator import ImportPDBOperator
 from .ui.animate_trajectory_operator import AnimateTrajectoryOperator
 from .ui.import_trajectory_panel import ImportTrajectoryPanel
-from .ui.segmentations_ui_list import SegmentationsUiList, SegmentationItem
+from .ui.segmentations_ui_list import (
+    SegmentationMethodsUiList,
+    SegmentationDomainCountsUiList,
+    SegmentationMethodItem,
+    SegmentationDomainCountItem
+)
 from .lib.segmentation import parse_segmentation_file
 
 def register():
     bpy.utils.register_class(ImportPDBOperator)
     bpy.utils.register_class(AnimateTrajectoryOperator)
     bpy.utils.register_class(ImportTrajectoryPanel)
-    bpy.utils.register_class(SegmentationsUiList)
-    bpy.utils.register_class(SegmentationItem)
+    bpy.utils.register_class(SegmentationMethodsUiList)
+    bpy.utils.register_class(SegmentationDomainCountsUiList)
+    bpy.utils.register_class(SegmentationMethodItem)
+    bpy.utils.register_class(SegmentationDomainCountItem)
 
     # PDB file input:
     bpy.types.Scene.ProteinRunway_pdb_path = bpy.props.StringProperty(
@@ -25,12 +32,22 @@ def register():
 
     # Segmentation TSV file input:
     def update_segmentation_path(self, value):
-        self.ProteinRunway_segmentations.clear()
+        self.ProteinRunway_segmentation_methods.clear()
+        self.ProteinRunway_segmentation_domain_counts.clear()
 
-        for (method, chopping) in parse_segmentation_file(value).items():
-            new_item = self.ProteinRunway_segmentations.add()
+        first_item = self.ProteinRunway_segmentation_methods.add()
+        first_item.method = "No segmentation"
+        first_item.domain_counts = '1'
+
+        for (method, domain_counts) in parse_segmentation_file(value).items():
+            new_item = self.ProteinRunway_segmentation_methods.add()
             new_item.method = method
-            new_item.chopping = chopping
+            new_item.domain_counts = ','.join(domain_counts.keys())
+
+            for (domain_count, chopping) in domain_counts.items():
+                new_item = self.ProteinRunway_segmentation_domain_counts.add()
+                new_item.domain_count = domain_count
+                new_item.chopping = chopping
 
     bpy.types.Scene.ProteinRunway_segmentation_path = bpy.props.StringProperty(
         name="File",
@@ -42,9 +59,14 @@ def register():
     )
 
     # Array of segmentations serialized as SegmentationItem properties
-    bpy.types.Scene.ProteinRunway_segmentations      = bpy.props.StringProperty()
-    bpy.types.Scene.ProteinRunway_segmentations      = bpy.props.CollectionProperty(type=SegmentationItem)
-    bpy.types.Scene.ProteinRunway_segmentation_index = bpy.props.IntProperty()
+    bpy.types.Scene.ProteinRunway_segmentation_methods = bpy.props.CollectionProperty(
+        type=SegmentationMethodItem
+    )
+    bpy.types.Scene.ProteinRunway_segmentation_domain_counts = bpy.props.CollectionProperty(
+        type=SegmentationDomainCountItem
+    )
+    bpy.types.Scene.ProteinRunway_segmentation_method_index = bpy.props.IntProperty()
+    bpy.types.Scene.ProteinRunway_segmentation_domain_count_index = bpy.props.IntProperty()
 
     # Progress bar progress value
     bpy.types.Scene.ProteinRunway_progress = bpy.props.FloatProperty()
@@ -59,12 +81,16 @@ def unregister():
     bpy.utils.unregister_class(ImportPDBOperator)
     bpy.utils.unregister_class(AnimateTrajectoryOperator)
     bpy.utils.unregister_class(ImportTrajectoryPanel)
-    bpy.utils.unregister_class(SegmentationsUiList)
-    bpy.utils.unregister_class(SegmentationItem)
+    bpy.utils.unregister_class(SegmentationMethodsUiList)
+    bpy.utils.unregister_class(SegmentationDomainCountsUiList)
+    bpy.utils.unregister_class(SegmentationMethodItem)
+    bpy.utils.unregister_class(SegmentationDomainCountItem)
 
     del bpy.types.Scene.ProteinRunway_pdb_path
     del bpy.types.Scene.ProteinRunway_segmentation_path
-    del bpy.types.Scene.ProteinRunway_segmentations
-    del bpy.types.Scene.ProteinRunway_segmentation_index
+    del bpy.types.Scene.ProteinRunway_segmentation_methods
+    del bpy.types.Scene.ProteinRunway_segmentation_domain_counts
+    del bpy.types.Scene.ProteinRunway_segmentation_method_index
+    del bpy.types.Scene.ProteinRunway_segmentation_domain_count_index
     del bpy.types.Scene.ProteinRunway_progress
     del bpy.types.Scene.ProteinRunway_add_convex_hull

--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -77,7 +77,22 @@ def register():
     bpy.types.Scene.ProteinRunway_segmentation_items = bpy.props.CollectionProperty(
         type=SegmentationItem
     )
-    bpy.types.Scene.ProteinRunway_segmentation_method_index = bpy.props.IntProperty()
+
+    def update_segmentation_index(self, context):
+        active_method_index       = self.ProteinRunway_segmentation_method_index
+        active_method             = self.ProteinRunway_segmentation_methods[active_method_index]
+        active_segmentation_index = self.ProteinRunway_segmentation_params_index
+        active_segmentation       = self.ProteinRunway_segmentation_items[active_segmentation_index]
+
+        if active_method.name != active_segmentation.method_name:
+            for index, item in enumerate(self.ProteinRunway_segmentation_items):
+                if item.method_name == active_method.name:
+                    self.ProteinRunway_segmentation_params_index = index
+                    break
+    bpy.types.Scene.ProteinRunway_segmentation_method_index = bpy.props.IntProperty(
+        update=update_segmentation_index
+    )
+
     bpy.types.Scene.ProteinRunway_segmentation_params_index = bpy.props.IntProperty()
 
     # Progress bar progress value

--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -36,9 +36,14 @@ def register():
         self.ProteinRunway_segmentation_methods.clear()
         self.ProteinRunway_segmentation_domain_counts.clear()
 
-        first_item = self.ProteinRunway_segmentation_methods.add()
-        first_item.method = "No segmentation"
-        first_item.domain_counts = '1'
+        first_method_item = self.ProteinRunway_segmentation_methods.add()
+        first_method_item.method = "No segmentation"
+        first_method_item.domain_counts = '1'
+
+        first_domain_count_item = self.ProteinRunway_segmentation_domain_counts.add()
+        first_domain_count_item.method = "No segmentation"
+        first_domain_count_item.domain_count = '1'
+        first_domain_count_item.chopping = ''
 
         for (method, domain_counts) in parse_segmentation_file(value).items():
             new_item = self.ProteinRunway_segmentation_methods.add()
@@ -47,6 +52,7 @@ def register():
 
             for (domain_count, chopping) in domain_counts.items():
                 new_item = self.ProteinRunway_segmentation_domain_counts.add()
+                new_item.method = method
                 new_item.domain_count = domain_count
                 new_item.chopping = chopping
 

--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -1,25 +1,25 @@
 import bpy
-import json
 
 from .ui.import_pdb_operator import ImportPDBOperator
 from .ui.animate_trajectory_operator import AnimateTrajectoryOperator
 from .ui.import_trajectory_panel import ImportTrajectoryPanel
 from .ui.segmentations_ui_list import (
     SegmentationMethodsUiList,
-    SegmentationDomainCountsUiList,
+    SegmentationParamsUiList,
     SegmentationMethodItem,
-    SegmentationDomainCountItem
+    SegmentationItem
 )
 from .lib.segmentation import parse_segmentation_file
+
 
 def register():
     bpy.utils.register_class(ImportPDBOperator)
     bpy.utils.register_class(AnimateTrajectoryOperator)
     bpy.utils.register_class(ImportTrajectoryPanel)
     bpy.utils.register_class(SegmentationMethodsUiList)
-    bpy.utils.register_class(SegmentationDomainCountsUiList)
+    bpy.utils.register_class(SegmentationParamsUiList)
     bpy.utils.register_class(SegmentationMethodItem)
-    bpy.utils.register_class(SegmentationDomainCountItem)
+    bpy.utils.register_class(SegmentationItem)
 
     # PDB file input:
     bpy.types.Scene.ProteinRunway_pdb_path = bpy.props.StringProperty(
@@ -33,17 +33,18 @@ def register():
     # Segmentation TSV file input:
     def update_segmentation_path(self, value):
         self.ProteinRunway_segmentation_path_storage = value
+
         self.ProteinRunway_segmentation_methods.clear()
-        self.ProteinRunway_segmentation_domain_counts.clear()
+        self.ProteinRunway_segmentation_items.clear()
 
         first_method_item = self.ProteinRunway_segmentation_methods.add()
         first_method_item.method = "No segmentation"
         first_method_item.domain_counts = '1'
 
-        first_domain_count_item = self.ProteinRunway_segmentation_domain_counts.add()
-        first_domain_count_item.method = "No segmentation"
-        first_domain_count_item.domain_count = '1'
-        first_domain_count_item.chopping = ''
+        first_item = self.ProteinRunway_segmentation_items.add()
+        first_item.method = "No segmentation"
+        first_item.domain_count = '1'
+        first_item.chopping = ''
 
         for (method, domain_counts) in parse_segmentation_file(value).items():
             new_item = self.ProteinRunway_segmentation_methods.add()
@@ -51,7 +52,7 @@ def register():
             new_item.domain_counts = ','.join(domain_counts.keys())
 
             for (domain_count, chopping) in domain_counts.items():
-                new_item = self.ProteinRunway_segmentation_domain_counts.add()
+                new_item = self.ProteinRunway_segmentation_items.add()
                 new_item.method = method
                 new_item.domain_count = domain_count
                 new_item.chopping = chopping
@@ -70,15 +71,16 @@ def register():
         get=lambda s: s.ProteinRunway_segmentation_path_storage
     )
 
-    # Array of segmentations serialized as SegmentationItem properties
+    # Array of segmentation methods
     bpy.types.Scene.ProteinRunway_segmentation_methods = bpy.props.CollectionProperty(
         type=SegmentationMethodItem
     )
-    bpy.types.Scene.ProteinRunway_segmentation_domain_counts = bpy.props.CollectionProperty(
-        type=SegmentationDomainCountItem
+    # Array of segmentations serialized as SegmentationItem properties
+    bpy.types.Scene.ProteinRunway_segmentation_items = bpy.props.CollectionProperty(
+        type=SegmentationItem
     )
     bpy.types.Scene.ProteinRunway_segmentation_method_index = bpy.props.IntProperty()
-    bpy.types.Scene.ProteinRunway_segmentation_domain_count_index = bpy.props.IntProperty()
+    bpy.types.Scene.ProteinRunway_segmentation_params_index = bpy.props.IntProperty()
 
     # Progress bar progress value
     bpy.types.Scene.ProteinRunway_progress = bpy.props.FloatProperty()
@@ -94,16 +96,16 @@ def unregister():
     bpy.utils.unregister_class(AnimateTrajectoryOperator)
     bpy.utils.unregister_class(ImportTrajectoryPanel)
     bpy.utils.unregister_class(SegmentationMethodsUiList)
-    bpy.utils.unregister_class(SegmentationDomainCountsUiList)
+    bpy.utils.unregister_class(SegmentationParamsUiList)
     bpy.utils.unregister_class(SegmentationMethodItem)
-    bpy.utils.unregister_class(SegmentationDomainCountItem)
+    bpy.utils.unregister_class(SegmentationItem)
 
     del bpy.types.Scene.ProteinRunway_pdb_path
     del bpy.types.Scene.ProteinRunway_segmentation_path_storage
     del bpy.types.Scene.ProteinRunway_segmentation_path
     del bpy.types.Scene.ProteinRunway_segmentation_methods
-    del bpy.types.Scene.ProteinRunway_segmentation_domain_counts
+    del bpy.types.Scene.ProteinRunway_segmentation_items
     del bpy.types.Scene.ProteinRunway_segmentation_method_index
-    del bpy.types.Scene.ProteinRunway_segmentation_domain_count_index
+    del bpy.types.Scene.ProteinRunway_segmentation_params_index
     del bpy.types.Scene.ProteinRunway_progress
     del bpy.types.Scene.ProteinRunway_add_convex_hull

--- a/blender/extension/__init__.py
+++ b/blender/extension/__init__.py
@@ -38,22 +38,20 @@ def register():
         self.ProteinRunway_segmentation_items.clear()
 
         first_method_item = self.ProteinRunway_segmentation_methods.add()
-        first_method_item.method = "No segmentation"
-        first_method_item.domain_counts = '1'
+        first_method_item.name = "No segmentation"
 
         first_item = self.ProteinRunway_segmentation_items.add()
-        first_item.method = "No segmentation"
+        first_item.method_name = first_method_item.name
         first_item.domain_count = '1'
         first_item.chopping = ''
 
-        for (method, domain_counts) in parse_segmentation_file(value).items():
+        for (method_name, domain_counts) in parse_segmentation_file(value).items():
             new_item = self.ProteinRunway_segmentation_methods.add()
-            new_item.method = method
-            new_item.domain_counts = ','.join(domain_counts.keys())
+            new_item.name = method_name
 
             for (domain_count, chopping) in domain_counts.items():
                 new_item = self.ProteinRunway_segmentation_items.add()
-                new_item.method = method
+                new_item.method_name = method_name
                 new_item.domain_count = domain_count
                 new_item.chopping = chopping
 

--- a/blender/extension/lib/segmentation.py
+++ b/blender/extension/lib/segmentation.py
@@ -1,18 +1,20 @@
 import csv
 import re
+from collections import defaultdict
 
 def parse_segmentation_file(path):
     """
     Expected columns: 'index', 'method', 'domain_count', 'chopping'
     """
-    segmentations = {}
+    # A nested dictionary of { <method>: { <domain_count>: <chopping> } }
+    segmentations = defaultdict(dict)
 
     # TODO (2024-11-17) Handle errors
 
     with open(path) as f:
         reader = csv.DictReader(f, delimiter='\t')
         for row in reader:
-            segmentations[row['method']] = row['chopping']
+            segmentations[row['method']][row['domain_count']] = row['chopping']
 
     return segmentations
 

--- a/blender/extension/ui/animate_trajectory_operator.py
+++ b/blender/extension/ui/animate_trajectory_operator.py
@@ -4,7 +4,7 @@ import mathutils
 
 import MDAnalysis as mda
 
-from ..lib.segmentation import generate_domain_ranges
+from .segmentations_ui_list import extract_selected_segmentation
 
 TIMER_INTERVAL = 0.001
 
@@ -30,23 +30,13 @@ class AnimateTrajectoryOperator(bpy.types.Operator):
         """
         Called once when the operator is invoked
         """
+        scene             = context.scene
         atom_mesh_objects = context.selected_objects
         self.meshes       = [o.data for o in atom_mesh_objects]
 
-        pdb_path      = context.scene.ProteinRunway_pdb_path
-        self.universe = mda.Universe(pdb_path)
-
-        # TODO (2024-11-19) Duplicates ImportPDBOperator
-        scene = context.scene
-        segmentations = scene.ProteinRunway_segmentations
-        if len(segmentations) > 0:
-            segmentation_index = scene.ProteinRunway_segmentation_index
-            selected_segmentation = segmentations[segmentation_index]
-
-            self.domain_regions = generate_domain_ranges(selected_segmentation.chopping)
-        else:
-            # One domain for the entire protein:
-            self.domain_regions = [[range(1, max(a.resnum for a in self.universe.atoms))]]
+        pdb_path            = context.scene.ProteinRunway_pdb_path
+        self.universe       = mda.Universe(pdb_path)
+        self.domain_regions = extract_selected_segmentation(scene, self.universe)
 
         context.window_manager.modal_handler_add(self)
         self.updating = False

--- a/blender/extension/ui/import_pdb_operator.py
+++ b/blender/extension/ui/import_pdb_operator.py
@@ -114,12 +114,6 @@ class ImportPDBOperator(bpy.types.Operator):
         material.diffuse_color = color
         material.use_nodes = True
 
-        # TODO: Investigate this material modification by Atomic Blender:
-        #
-        # mat_P_BSDF = next(n for n in material.node_tree.nodes
-        #                   if n.type == "BSDF_PRINCIPLED")
-        # mat_P_BSDF.inputs['Base Color'].default_value = color
-
         material.name = f"{domain_name}_material"
 
         atom_mesh = bpy.data.meshes.new(f"{domain_name}_mesh")
@@ -165,18 +159,6 @@ class ImportPDBOperator(bpy.types.Operator):
 
         atom_mesh_object.instance_type = 'VERTS'
 
-        # TODO (2024-11-14) Taken from Atomic Blender, check if it's necessary:
-
-        # Note the collection where the ball was placed into.
-        coll_all = representative_ball.users_collection
-        if len(coll_all) > 0:
-            coll_past = coll_all[0]
-        else:
-            coll_past = bpy.context.scene.collection
-
-        # Put the atom into the new collection 'atom' and ...
         self.collection_protein.objects.link(representative_ball)
-        # ... unlink the atom from the other collection.
-        coll_past.objects.unlink(representative_ball)
 
         return atom_mesh_object

--- a/blender/extension/ui/import_pdb_operator.py
+++ b/blender/extension/ui/import_pdb_operator.py
@@ -5,7 +5,7 @@ import bmesh
 
 import MDAnalysis as mda
 
-from ..lib.segmentation import generate_domain_ranges
+from .segmentations_ui_list import extract_selected_segmentation
 
 COLORS = [
     (1.0, 1.0, 1.0, 1),  # white
@@ -44,7 +44,7 @@ class ImportPDBOperator(bpy.types.Operator):
             return {'CANCELLED'}
 
         try:
-            u = mda.Universe(pdb_path)
+            mda_universe = mda.Universe(pdb_path)
         except ValueError as e:
             self.report({'ERROR'}, f"MDAnalysis error: {e}")
             return {'CANCELLED'}
@@ -52,17 +52,9 @@ class ImportPDBOperator(bpy.types.Operator):
         self.collection_protein = bpy.data.collections.new(protein_name)
         scene.collection.children.link(self.collection_protein)
 
-        segmentations = scene.ProteinRunway_segmentations
-        if len(segmentations) > 0:
-            segmentation_index = scene.ProteinRunway_segmentation_index
-            selected_segmentation = segmentations[segmentation_index]
+        domain_regions = extract_selected_segmentation(scene, mda_universe)
 
-            domain_regions = generate_domain_ranges(selected_segmentation.chopping)
-        else:
-            # One domain for the entire protein:
-            domain_regions = [[range(1, max(a.resnum for a in u.atoms))]]
-
-        atom_mesh_objects = self.draw_alpha_carbons(u, domain_regions, add_convex_hull)
+        atom_mesh_objects = self.draw_alpha_carbons(mda_universe, domain_regions, add_convex_hull)
 
         for o in atom_mesh_objects:
             o.select_set(True)
@@ -72,7 +64,7 @@ class ImportPDBOperator(bpy.types.Operator):
         # multiple trajectories
         #
         # Fit the number of global frames to this trajectory's length.
-        bpy.data.scenes[0].frame_end = len(u.trajectory)
+        bpy.data.scenes[0].frame_end = len(mda_universe.trajectory)
 
         return {'FINISHED'}
 

--- a/blender/extension/ui/import_trajectory_panel.py
+++ b/blender/extension/ui/import_trajectory_panel.py
@@ -3,7 +3,7 @@ import bpy
 from .import_pdb_operator import ImportPDBOperator
 from .segmentations_ui_list import (
     SegmentationMethodsUiList,
-    SegmentationDomainCountsUiList,
+    SegmentationParamsUiList,
 )
 
 
@@ -41,12 +41,12 @@ class ImportTrajectoryPanel(bpy.types.Panel):
                 active_propname="ProteinRunway_segmentation_method_index",
             )
             row.template_list(
-                listtype_name=SegmentationDomainCountsUiList.bl_idname,
-                list_id=SegmentationDomainCountsUiList.bl_idname,
+                listtype_name=SegmentationParamsUiList.bl_idname,
+                list_id=SegmentationParamsUiList.bl_idname,
                 dataptr=scene,
-                propname="ProteinRunway_segmentation_domain_counts",
+                propname="ProteinRunway_segmentation_items",
                 active_dataptr=scene,
-                active_propname="ProteinRunway_segmentation_domain_count_index",
+                active_propname="ProteinRunway_segmentation_params_index",
             )
 
         layout.separator()

--- a/blender/extension/ui/import_trajectory_panel.py
+++ b/blender/extension/ui/import_trajectory_panel.py
@@ -24,7 +24,7 @@ class ImportTrajectoryPanel(bpy.types.Panel):
 
         layout.separator()
 
-        layout.label(text="Segmentation mapping file", icon="AREA_JOIN")
+        layout.label(text="Segmentation mapping file", icon="SPREADSHEET")
         row = layout.row()
         row.prop(scene, "ProteinRunway_segmentation_path")
 

--- a/blender/extension/ui/import_trajectory_panel.py
+++ b/blender/extension/ui/import_trajectory_panel.py
@@ -1,7 +1,10 @@
 import bpy
 
 from .import_pdb_operator import ImportPDBOperator
-from .segmentations_ui_list import SegmentationsUiList
+from .segmentations_ui_list import (
+    SegmentationMethodsUiList,
+    SegmentationDomainCountsUiList,
+)
 
 
 class ImportTrajectoryPanel(bpy.types.Panel):
@@ -25,15 +28,25 @@ class ImportTrajectoryPanel(bpy.types.Panel):
         row = layout.row()
         row.prop(scene, "ProteinRunway_segmentation_path")
 
-        if len(scene.ProteinRunway_segmentations) > 0:
+        if len(scene.ProteinRunway_segmentation_methods) > 0:
             layout.row().label(text="Available segmentations", icon="AREA_JOIN")
-            layout.row().template_list(
-                listtype_name=SegmentationsUiList.bl_idname,
-                list_id=SegmentationsUiList.bl_idname,
+
+            row = layout.row()
+            row.template_list(
+                listtype_name=SegmentationMethodsUiList.bl_idname,
+                list_id=SegmentationMethodsUiList.bl_idname,
                 dataptr=scene,
-                propname="ProteinRunway_segmentations",
+                propname="ProteinRunway_segmentation_methods",
                 active_dataptr=scene,
-                active_propname="ProteinRunway_segmentation_index",
+                active_propname="ProteinRunway_segmentation_method_index",
+            )
+            row.template_list(
+                listtype_name=SegmentationDomainCountsUiList.bl_idname,
+                list_id=SegmentationDomainCountsUiList.bl_idname,
+                dataptr=scene,
+                propname="ProteinRunway_segmentation_domain_counts",
+                active_dataptr=scene,
+                active_propname="ProteinRunway_segmentation_domain_count_index",
             )
 
         layout.separator()

--- a/blender/extension/ui/segmentations_ui_list.py
+++ b/blender/extension/ui/segmentations_ui_list.py
@@ -6,10 +6,7 @@ class SegmentationMethodItem(bpy.types.PropertyGroup):
     """
     A single segmentation method, wrapped in a custom class
     """
-    method: bpy.props.StringProperty(
-        name="Method",
-        description="Segmentation method",
-    )
+    name: bpy.props.StringProperty(name="Method name")
 
 
 class SegmentationItem(bpy.types.PropertyGroup):
@@ -17,20 +14,9 @@ class SegmentationItem(bpy.types.PropertyGroup):
     Group of properties representing an item in the list of domain counts to
     pick from for a given method.
     """
-    method: bpy.props.StringProperty(
-        name="Method",
-        description="Segmentation method",
-    )
-
-    domain_count: bpy.props.StringProperty(
-        name="DomainCount",
-        description="Number of domains for a given method",
-    )
-
-    chopping: bpy.props.StringProperty(
-        name="Chopping",
-        description="Residue ranges grouped in domains",
-    )
+    method_name:  bpy.props.StringProperty(name="Method name")
+    domain_count: bpy.props.StringProperty(name="Domain count")
+    chopping:     bpy.props.StringProperty(name="Chopping")
 
 
 class SegmentationMethodsUiList(bpy.types.UIList):
@@ -40,39 +26,20 @@ class SegmentationMethodsUiList(bpy.types.UIList):
 
     bl_idname = "PROTEINRUNWAY_UL_segmentation_methods_ui_list"
 
-    def draw_item(
-        self,
-        context,
-        layout,
-        data,
-        item,
-        icon,
-        active_data,
-        active_propname,
-        index,
-    ):
-        layout.label(text=item.method, icon='FILE_3D')
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.label(text=item.name, icon='GRAPH')
 
 
 class SegmentationParamsUiList(bpy.types.UIList):
     """
-    List of possible segmentations of domains
+    List of possible segmentations of domains, represented by the domain count,
+    but bound to a particular method.
     """
 
     bl_idname = "PROTEINRUNWAY_UL_segmentation_params_ui_list"
 
-    def draw_item(
-        self,
-        context,
-        layout,
-        data,
-        item,
-        icon,
-        active_data,
-        active_propname,
-        index,
-    ):
-        layout.label(text=item.domain_count, icon='FILE_3D')
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.label(text=item.domain_count, icon='OPTIONS')
 
     def filter_items(self, context, data, propname):
         scene = context.scene
@@ -87,7 +54,7 @@ class SegmentationParamsUiList(bpy.types.UIList):
         filter_flags = [self.bitflag_filter_item] * len(items)
 
         for index, item in enumerate(items):
-            if active_method.method != item.method:
+            if active_method.name != item.method_name:
                 filter_flags[index] &= True
 
         return filter_flags, []
@@ -101,13 +68,13 @@ def extract_selected_segmentation(scene, mda_universe):
         active_segmentation = scene.ProteinRunway_segmentation_items[active_segmentation_index]
         active_method       = scene.ProteinRunway_segmentation_methods[active_method_index]
 
-        if active_method.method != active_segmentation.method:
+        if active_method.name != active_segmentation.method_name:
             # then the "selected" one in the list is actually hidden, so let's
             # just take the first one that is relevant to this method:
             active_segmentation = next((
                 item
                 for item in scene.ProteinRunway_segmentation_items
-                if item.method == active_method.method
+                if item.method_name == active_method.name
             ), None)
     else:
         active_segmentation = None

--- a/blender/extension/ui/segmentations_ui_list.py
+++ b/blender/extension/ui/segmentations_ui_list.py
@@ -1,27 +1,40 @@
 import bpy
 
-class SegmentationItem(bpy.types.PropertyGroup):
+class SegmentationMethodItem(bpy.types.PropertyGroup):
     """
-    Group of properties representing an item in the segmentation list
+    Group of properties representing an item in the segmentatio methods list
     """
     method: bpy.props.StringProperty(
         name="Method",
         description="Segmentation method",
-        default="",
+    )
+
+    domain_counts: bpy.props.StringProperty(
+        name="DomainCounts",
+        description="Number of domains for a given method, comma-separated",
+    )
+
+class SegmentationDomainCountItem(bpy.types.PropertyGroup):
+    """
+    Group of properties representing an item in the list of domain counts to
+    pick from for a given method.
+    """
+    domain_count: bpy.props.StringProperty(
+        name="DomainCount",
+        description="Number of domains for a given method",
     )
 
     chopping: bpy.props.StringProperty(
         name="Chopping",
         description="Residue ranges grouped in domains",
-        default="",
     )
 
-class SegmentationsUiList(bpy.types.UIList):
+class SegmentationMethodsUiList(bpy.types.UIList):
     """
     List of possible segmentations of domains
     """
 
-    bl_idname = "PROTEINRUNWAY_UL_segmentations_ui_list"
+    bl_idname = "PROTEINRUNWAY_UL_segmentation_methods_ui_list"
 
     def draw_item(
         self,
@@ -35,3 +48,23 @@ class SegmentationsUiList(bpy.types.UIList):
         index,
     ):
         layout.label(text=item.method, icon='FILE_3D')
+
+class SegmentationDomainCountsUiList(bpy.types.UIList):
+    """
+    List of possible segmentations of domains
+    """
+
+    bl_idname = "PROTEINRUNWAY_UL_segmentation_domain_counts_ui_list"
+
+    def draw_item(
+        self,
+        context,
+        layout,
+        data,
+        item,
+        icon,
+        active_data,
+        active_propname,
+        index,
+    ):
+        layout.label(text=item.domain_count, icon='FILE_3D')

--- a/blender/extension/ui/segmentations_ui_list.py
+++ b/blender/extension/ui/segmentations_ui_list.py
@@ -2,6 +2,7 @@ import bpy
 
 from ..lib.segmentation import generate_domain_ranges
 
+
 class SegmentationMethodItem(bpy.types.PropertyGroup):
     """
     A single segmentation method, wrapped in a custom class
@@ -47,9 +48,6 @@ class SegmentationParamsUiList(bpy.types.UIList):
         active_method_index = scene.ProteinRunway_segmentation_method_index
         active_method       = scene.ProteinRunway_segmentation_methods[active_method_index]
 
-        active_params_index = scene.ProteinRunway_segmentation_params_index
-        active_item         = scene.ProteinRunway_segmentation_items[active_params_index]
-
         items = scene.ProteinRunway_segmentation_items
         filter_flags = [self.bitflag_filter_item] * len(items)
 
@@ -61,10 +59,9 @@ class SegmentationParamsUiList(bpy.types.UIList):
 
 
 def extract_selected_segmentation(scene, mda_universe):
-    active_method_index       = scene.ProteinRunway_segmentation_method_index
     active_segmentation_index = scene.ProteinRunway_segmentation_params_index
-
     active_segmentation = None
+
     if len(scene.ProteinRunway_segmentation_items) > 0:
         active_segmentation = scene.ProteinRunway_segmentation_items[active_segmentation_index]
 

--- a/blender/extension/ui/segmentations_ui_list.py
+++ b/blender/extension/ui/segmentations_ui_list.py
@@ -64,20 +64,9 @@ def extract_selected_segmentation(scene, mda_universe):
     active_method_index       = scene.ProteinRunway_segmentation_method_index
     active_segmentation_index = scene.ProteinRunway_segmentation_params_index
 
+    active_segmentation = None
     if len(scene.ProteinRunway_segmentation_items) > 0:
         active_segmentation = scene.ProteinRunway_segmentation_items[active_segmentation_index]
-        active_method       = scene.ProteinRunway_segmentation_methods[active_method_index]
-
-        if active_method.name != active_segmentation.method_name:
-            # then the "selected" one in the list is actually hidden, so let's
-            # just take the first one that is relevant to this method:
-            active_segmentation = next((
-                item
-                for item in scene.ProteinRunway_segmentation_items
-                if item.method_name == active_method.name
-            ), None)
-    else:
-        active_segmentation = None
 
     if active_segmentation is not None and active_segmentation.chopping != '':
         domain_regions = generate_domain_ranges(active_segmentation.chopping)

--- a/lib/segmentation_parsers.py
+++ b/lib/segmentation_parsers.py
@@ -96,7 +96,7 @@ class GeostasParser(SegmentationParser):
             k           = int(re.findall(r'\d\d', Path(file).stem)[0])
             atom_groups = json.loads(Path(file).read_text())
             chopping    = self.generate_geostas_chopping(atom_groups)
-            method      = f"GeoStaS K-means, K={k}"
+            method      = f"GeoStaS K-means"
 
             segmentations.append((method, len(atom_groups), chopping))
 
@@ -104,7 +104,7 @@ class GeostasParser(SegmentationParser):
             k           = int(re.findall(r'\d\d', Path(file).stem)[0])
             atom_groups = json.loads(Path(file).read_text())
             chopping    = self.generate_geostas_chopping(atom_groups)
-            method      = f"GeoStaS Hierarchical, K={k}"
+            method      = f"GeoStaS Hierarchical"
 
             segmentations.append((method, len(atom_groups), chopping))
 

--- a/tests/segmentation_parser_test.py
+++ b/tests/segmentation_parser_test.py
@@ -54,7 +54,7 @@ class TestSegmentationParser(unittest.TestCase):
         result = geostas.parse()
         self.assertEqual(
             result,
-            [('GeoStaS Hierarchical, K=2', 2, '1-3,10-12_50-50_60-60')],
+            [('GeoStaS Hierarchical', 2, '1-3,10-12_50-50_60-60')],
         )
 
         self._create_geostas_clustering_file('clustering_kmeans_03.json', [
@@ -68,8 +68,8 @@ class TestSegmentationParser(unittest.TestCase):
         self.assertEqual(
             result,
             [
-                ('GeoStaS K-means, K=3', 3, '1-3,10-12,50-50_60-60'),
-                ('GeoStaS Hierarchical, K=2', 2, '1-3,10-12_50-50_60-60'),
+                ('GeoStaS K-means', 3, '1-3,10-12,50-50_60-60'),
+                ('GeoStaS Hierarchical', 2, '1-3,10-12_50-50_60-60'),
             ],
         )
 


### PR DESCRIPTION
This PR splits the single segmentation list into two lists with separate "method" and "domain count" sections. I might at some point pass through and change "domain count" to "params" and just sort of reframe this TSV column to be the parameterisation of the method, but we'll see.

![2024-12-04-224611_1920x1080_scrot](https://github.com/user-attachments/assets/0650dacc-998c-49fa-8e6d-9585df342c4f)
